### PR TITLE
Monoid instance for FreeT

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "purescript-control": "^2.0.0",
     "purescript-tailrec": "^2.0.0",
     "purescript-transformers": "^2.0.1",
-    "purescript-exists": "^2.0.0"
+    "purescript-exists": "^2.0.0",
+    "purescript-eff": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "purescript-control": "^2.0.0",
     "purescript-tailrec": "^2.0.0",
     "purescript-transformers": "^2.0.1",
-    "purescript-exists": "^2.0.0",
-    "purescript-eff": "^2.0.0"
+    "purescript-exists": "^2.0.0"
   }
 }

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -16,12 +16,12 @@ import Prelude
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
-import Data.Semigroup (class Semigroup, (<>))
+import Data.Semigroup (class Semigroup, append)
 import Data.Monoid (class Monoid, mempty)
 
-import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Apply (lift2)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM)
-import Control.Monad.Trans.Class (class MonadTrans, lift)
+import Control.Monad.Trans.Class (class MonadTrans)
 
 -- | Instead of implementing `bind` directly, we capture the bind using this data structure, to
 -- | evaluate later.
@@ -80,16 +80,10 @@ instance monadRecFreeT :: (Functor f, Monad m) => MonadRec (FreeT f m) where
         Done a -> pure a
 
 instance semigroupFreeT :: (Functor f, Monad m, Monoid w) => Semigroup (FreeT f m w) where
-  append x y = do
-    x' <- x
-    y' <- y
-    pure (x' <> y')
+  append = lift2 append
 
 instance monoidFreeT :: (Functor f, Monad m, Monoid w) => Monoid (FreeT f m w) where
   mempty = pure mempty
-
--- instance monadEffFreeT :: (Functor f, MonadEff m) => MonadEff (FreeT f m) where
---   liftEff x = lift (liftEff x)
 
 -- | Lift an action from the functor `f` to a `FreeT` action.
 liftFreeT :: forall f m a. (Functor f, Monad m) => f a -> FreeT f m a

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -79,7 +79,7 @@ instance monadRecFreeT :: (Functor f, Monad m) => MonadRec (FreeT f m) where
         Loop s1 -> go s1
         Done a -> pure a
 
-instance semigroupFreeT :: (Functor f, Monad m, Monoid w) => Semigroup (FreeT f m w) where
+instance semigroupFreeT :: (Functor f, Monad m, Semigroup w) => Semigroup (FreeT f m w) where
   append = lift2 append
 
 instance monoidFreeT :: (Functor f, Monad m, Monoid w) => Monoid (FreeT f m w) where

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -16,6 +16,8 @@ import Prelude
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
+import Data.Semigroup (class Semigroup, (<>))
+import Data.Monoid (class Monoid, mempty)
 
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM)
@@ -77,8 +79,17 @@ instance monadRecFreeT :: (Functor f, Monad m) => MonadRec (FreeT f m) where
         Loop s1 -> go s1
         Done a -> pure a
 
-instance monadEffFreeT :: (Functor f, MonadEff m) => MonadEff (FreeT f m) where
-  liftEff x = lift (liftEff x)
+instance semigroupFreeT :: (Functor f, Monad m, Monoid w) => Semigroup (FreeT f m w) where
+  append x y = do
+    x' <- x
+    y' <- y
+    pure (x' <> y')
+
+instance monoidFreeT :: (Functor f, Monad m, Monoid w) => Monoid (FreeT f m w) where
+  mempty = pure mempty
+
+-- instance monadEffFreeT :: (Functor f, MonadEff m) => MonadEff (FreeT f m) where
+--   liftEff x = lift (liftEff x)
 
 -- | Lift an action from the functor `f` to a `FreeT` action.
 liftFreeT :: forall f m a. (Functor f, Monad m) => f a -> FreeT f m a

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -17,8 +17,9 @@ import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
 
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM)
-import Control.Monad.Trans.Class (class MonadTrans)
+import Control.Monad.Trans.Class (class MonadTrans, lift)
 
 -- | Instead of implementing `bind` directly, we capture the bind using this data structure, to
 -- | evaluate later.
@@ -75,6 +76,9 @@ instance monadRecFreeT :: (Functor f, Monad m) => MonadRec (FreeT f m) where
       f s >>= case _ of
         Loop s1 -> go s1
         Done a -> pure a
+
+instance monadEffFreeT :: (Functor f, MonadEff m) => MonadEff (FreeT f m) where
+  liftEff x = lift (liftEff x)
 
 -- | Lift an action from the functor `f` to a `FreeT` action.
 liftFreeT :: forall f m a. (Functor f, Monad m) => f a -> FreeT f m a

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -16,7 +16,6 @@ import Prelude
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
-import Data.Semigroup (class Semigroup, append)
 import Data.Monoid (class Monoid, mempty)
 
 import Control.Apply (lift2)


### PR DESCRIPTION
This is a pretty terrible pull request, but I still think the idea is valid.

> Given any Monad `m`, and Monoid `w`, you can make `m w` a Monoid

It wouldn't be wise to write this instance for _every_ monad, Haskell gets away with it by cherrypicking instances - they have one for `IO` and `Maybe` for instance, but that's about it. Also, this would conflate with the meaning behind the monadic instance for lists `[]`, so I think it's wise to stay away from that level of generality.

However, this instance for FreeT (and nest, Eff and Aff) could be useful. In my case, I'm using them to "merge" some `PerformAction` routines in Thermite:

```purescript
T.simpleSpec (performAction1 <> performAction2 <> ...) render
```

The monoid instance for `Spec` should also be capable of using this behavior in FreeT (and CoTransformer).