### PR TITLE
Add instance for MonadAff

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "purescript-exists": "^4.0.0",
     "purescript-prelude": "^4.0.0",
     "purescript-tailrec": "^4.0.0",
-    "purescript-transformers": "^4.0.0"
+    "purescript-transformers": "^4.0.0",
+    "purescript-aff": "^5.1.1"
   },
   "devDependencies": {
     "purescript-console": "^4.0.0"

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -24,6 +24,7 @@ import Control.Monad.Writer.Class (class MonadTell, tell)
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
+import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
 
 -- | Instead of implementing `bind` directly, we capture the bind using this data structure, to
@@ -90,6 +91,9 @@ instance monoidFreeT :: (Functor f, Monad m, Monoid w) => Monoid (FreeT f m w) w
 
 instance monadEffectFreeT :: (Functor f, MonadEffect m) => MonadEffect (FreeT f m) where
   liftEffect = lift <<< liftEffect
+
+instance monadAffFreeT :: (Functor f, MonadAff m) => MonadAff (FreeT f m) where
+  liftAff = lift <<< liftAff
 
 instance monadAskFreeT :: (Functor f, MonadAsk r m) => MonadAsk r (FreeT f m) where
   ask = lift ask


### PR DESCRIPTION
## What does this pull request do?

Fixes #13 by adding an instance for `MonadAff`, now that `purescript-aff` is part of the `core` / `contrib` packages. Introduces a new dependency, `purescript-aff`.