### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#34 by @thomashoneyman)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-freet/releases/tag/v6.0.0) - 2021-02-26
 

--- a/src/Control/Comonad/Cofree/Trans.purs
+++ b/src/Control/Comonad/Cofree/Trans.purs
@@ -42,7 +42,7 @@ cofreeT'
   :: forall f w a
    . w (Tuple a (f (CofreeT f w a)))
   -> CofreeT f w a
-cofreeT' t = CofreeT $ (\_ -> t)
+cofreeT' t = CofreeT (\_ -> t)
 
 -- | Unpack `CofreeT` into the inner computation.
 runCofreeT :: forall f w a. CofreeT f w a -> w (Tuple a (f (CofreeT f w a)))
@@ -63,9 +63,8 @@ instance functorCofreeT :: (Functor w, Functor f) => Functor (CofreeT f w) where
 
 instance applyCofreeT :: (Apply w, Apply f) => Apply (CofreeT f w) where
   apply (CofreeT innerF) (CofreeT inner) =
-    CofreeT
-      $ \_ ->
-          go <$> innerF unit <*> inner unit
+    CofreeT $ \_ ->
+      go <$> innerF unit <*> inner unit
     where
     go (Tuple f nextF) (Tuple x nextX) =
       Tuple (f x) (lift2 (<*>) nextF nextX)
@@ -75,12 +74,11 @@ instance applicativeCofreeT :: (Applicative w, Apply f, Plus f) => Applicative (
 
 instance bindCofreeT :: (Monad w, Alt f, Apply f) => Bind (CofreeT f w) where
   bind (CofreeT inner) f =
-    CofreeT
-      $ \_ -> do
-          (Tuple a m) <- inner unit
-          let (CofreeT next) = f a
-          (Tuple b n) <- next unit
-          pure $ Tuple b (n <|> map (_ >>= f) m)
+    CofreeT $ \_ -> do
+      (Tuple a m) <- inner unit
+      let (CofreeT next) = f a
+      (Tuple b n) <- next unit
+      pure $ Tuple b (n <|> map (_ >>= f) m)
 
 instance monadCofreeT :: (Monad w, Plus f, Apply f) => Monad (CofreeT f w)
 

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -50,16 +50,16 @@ resume = tailRecM go
   where
   go :: FreeT f m a -> m (Step (FreeT f m a) (Either a (f (FreeT f m a))))
   go (FreeT f) = map Done (f unit)
-  go (Bind e) = do 
-    let 
-      onBound (Bound bound' f) = case bound' unit of
+  go (Bind e) = 
+    e # runExists \(Bound bound' f) ->
+      case bound' unit of
         FreeT m ->
           m unit >>= case _ of
             Left a -> pure (Loop (f a))
             Right fc -> pure (Done (Right (map (\h -> h >>= f) fc)))
-        Bind e1 -> runExists (\(Bound m1 f1) -> pure (Loop (bind (m1 unit) (\z -> f1 z >>= f)))) e1
-
-    runExists onBound e
+        Bind e1 -> 
+          e1 # runExists \(Bound m1 f1) -> 
+            pure (Loop (bind (m1 unit) (\z -> f1 z >>= f))))
 
 instance functorFreeT :: (Functor f, Functor m) => Functor (FreeT f m) where
   map f (FreeT m) = FreeT \_ -> map (bimap f (map (map f))) (m unit)

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -50,15 +50,15 @@ resume = tailRecM go
   where
   go :: FreeT f m a -> m (Step (FreeT f m a) (Either a (f (FreeT f m a))))
   go (FreeT f) = map Done (f unit)
-  go (Bind e) = 
+  go (Bind e) =
     e # runExists \(Bound bound' f) ->
       case bound' unit of
         FreeT m ->
           m unit >>= case _ of
             Left a -> pure (Loop (f a))
             Right fc -> pure (Done (Right (map (\h -> h >>= f) fc)))
-        Bind e1 -> 
-          e1 # runExists \(Bound m1 f1) -> 
+        Bind e1 ->
+          e1 # runExists \(Bound m1 f1) ->
             pure (Loop (bind (m1 unit) (\z -> f1 z >>= f)))
 
 instance functorFreeT :: (Functor f, Functor m) => Functor (FreeT f m) where

--- a/src/Control/Monad/Free/Trans.purs
+++ b/src/Control/Monad/Free/Trans.purs
@@ -59,7 +59,7 @@ resume = tailRecM go
             Right fc -> pure (Done (Right (map (\h -> h >>= f) fc)))
         Bind e1 -> 
           e1 # runExists \(Bound m1 f1) -> 
-            pure (Loop (bind (m1 unit) (\z -> f1 z >>= f))))
+            pure (Loop (bind (m1 unit) (\z -> f1 z >>= f)))
 
 instance functorFreeT :: (Functor f, Functor m) => Functor (FreeT f m) where
   map f (FreeT m) = FreeT \_ -> map (bimap f (map (map f))) (m unit)

--- a/test/CofreeTExample.purs
+++ b/test/CofreeTExample.purs
@@ -14,10 +14,10 @@ type IndexedList = CofreeT List Maybe Int
 list :: IndexedList
 list = cofreeT (go 5)
   where
-    go :: Int -> Unit -> Maybe (Tuple Int (List IndexedList))
-    go 0 _ = Just $ Tuple 0 Nil
-    go 5 _ = Just $ Tuple 5 (fromFoldable $ cofreeT <$> (go <$> [4, 3]))
-    go i _ = Just $ Tuple i (pure $ cofreeT (go (i - 1)))
+  go :: Int -> Unit -> Maybe (Tuple Int (List IndexedList))
+  go 0 _ = Just $ Tuple 0 Nil
+  go 5 _ = Just $ Tuple 5 (fromFoldable $ cofreeT <$> (go <$> [ 4, 3 ]))
+  go i _ = Just $ Tuple i (pure $ cofreeT (go (i - 1)))
 
 annotations :: IndexedList -> List (Maybe Int)
 annotations il = head il : join (annotations <$> fromMaybe mempty (tail il))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -36,7 +36,8 @@ mockTeletype = runFreeT interp
 
 -- Also see purescript-safely
 replicateM_ :: forall m a. MonadRec m => Int -> m a -> m Unit
-replicateM_ n x = tailRecM step n where
+replicateM_ n x = tailRecM step n
+  where
   step :: Int -> m (Step Int Unit)
   step 0 = pure (Done unit)
   step m = x $> Loop (m - 1)


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
